### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+Changelog:
+==========
+* 2018-02-16 by Christian Schindler
+  - Added CHANGELOG.md (this) file to get an idea what was changed. 
+  - UTF-8 support: csv export from TUG-Online must be utf-8. Now umlauts and special characters are possible
+  - HTML-Seating Plan:
+    - Names in the HTML seating plan are truncated (with trailing horizontal ellipsis) when longer than 10 characters 
+    - Row and column numbering on all sides of the table
+    - Turning table (-u for lecturer view) now browser independent 
+  - Fixed latex source: usepackage utf8x; all generated pdfs correctyl display  umlauts and special characters in names
+  - Fixed latex source: intendation removed of first line in first paragraph in Students_Checklist_by_Seat.pdf 
+* 2017-06-02 by Christian Schindler
+  - Deal with student IDs with 8 digits
+  - Added new lecture hall HS_I Rechbauerstr. 12, 8010 Graz (basement)
+* 2017-01-31
+  - New Option: filling seats from front
+  - Excluded seats for disabled in HS_P1 - last row 12|13, 14|15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ Changelog:
   - UTF-8 support: csv export from TUG-Online must be utf-8. Now umlauts and special characters are possible
   - HTML-Seating Plan:
     - Names in the HTML seating plan are truncated (with trailing horizontal ellipsis) when longer than 10 characters 
-    - Row and column numbering on all sides of the table
-    - Turning table (-u for lecturer view) now browser independent 
+    - Row and column numbering on all sides of the seating plan
+    - Turning table (-u opton for lecturer view) now browser independent 
   - Fixed latex source: usepackage utf8x; all generated pdfs correctyl display  umlauts and special characters in names
   - Fixed latex source: intendation removed of first line in first paragraph in Students_Checklist_by_Seat.pdf 
 * 2017-06-02 by Christian Schindler
   - Deal with student IDs with 8 digits
   - Added new lecture hall HS_I Rechbauerstr. 12, 8010 Graz (basement)
-* 2017-01-31
+* 2017-01-31 by Christian Schindler
   - New Option: filling seats from front
   - Excluded seats for disabled in HS_P1 - last row 12|13, 14|15

--- a/GenerateSeatingPlan.py
+++ b/GenerateSeatingPlan.py
@@ -579,13 +579,24 @@ def GenerateLatexfileSortedByStudentLastname(lecture_room, list_of_students_with
     file.flush()
     os.fsync(file.fileno())
 
+def MangleNameIfLongerThanThresholdForUnicode(name, threshold):
+	if len(name) > threshold:
+		return name[:threshold-3]+u"\u2026"
+	else:
+		return name
+
+def MangleNameIfLongerThanThresholdForHTML(name, threshold):
+	if len(name) > threshold:
+		return name[:threshold-2]+"&hellip;"
+	else:
+		return name
+
 
 def GenerateHtmlFileWithTableFormat(lecture_room, list_of_students_with_seats):
 
     # FIXXME: Sizing needs some improvement.
-    # FIXXME: Turning text upside down might not work for all browsers.
 
-    htmlfile = open(FILENAME_MAIN_TABLE_WITHOUT_EXTENSION + '.html', 'w')
+    htmlfile = codecs.open(FILENAME_MAIN_TABLE_WITHOUT_EXTENSION + '.html', 'w','utf-8')
 
     htmlfile.write('<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"\n')
     htmlfile.write('        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">\n')
@@ -596,9 +607,7 @@ def GenerateHtmlFileWithTableFormat(lecture_room, list_of_students_with_seats):
     htmlfile.write('		content="text/html;charset=iso-8859-1" />\n')
     htmlfile.write('		<STYLE type="text/css">\n')
     htmlfile.write('		table {table-layout: fixed;}\n')
-    htmlfile.write('    td {border: 1px solid #000000; text-align: center; width: 100px; font-size: 10pt; height: 60px; %s}\n' \
-       % ("webkit-transform: rotate(-180deg); -moz-transform: rotate(-180deg); filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=2);" \
-         if options.tableturn else ""))
+    htmlfile.write('    td {border: 1px solid #000000; text-align: center; width: 100px; font-size: 10pt; height: 60px; %s}\n')
     htmlfile.write('    .empty {background-color: #EEEEEE}\n')
     htmlfile.write('    .omit {font-style: bold; font-size: 20pt; background-color: #AAAAAA}\n')
     htmlfile.write('    .header {font-size: 20pt; font-style: bold}\n')
@@ -606,18 +615,36 @@ def GenerateHtmlFileWithTableFormat(lecture_room, list_of_students_with_seats):
     htmlfile.write('    </STYLE>\n')
     htmlfile.write('</head>\n')
     htmlfile.write('<body>\n')
-    htmlfile.write('<table style="width: %dpx;">\n' % ((lecture_room['columns'] + 1) * 100))
+    hsize = ((lecture_room['columns'] + 2) * 100)
+    if options.tableturn:
+		hsize = ((lecture_room['columns'] + 3) * 100)
+    htmlfile.write('<table style="width: %dpx;">\n' % hsize)
+    if options.tableturn:
+		htmlfile.write('<tfoot>\n')
     htmlfile.write('<tr><td class="number">&nbsp;</td><td class="header" colspan="%d" style="width: %dpx">Front</td></tr>\n' % \
        (lecture_room['columns'], (lecture_room['columns']) * 100))
+    if options.tableturn:
+		htmlfile.write('</tfoot>\n')
+    # --
+    htmlfile.write('<tbody>\n')
     htmlfile.write('<tr>\n')
     htmlfile.write('<td class="number">&nbsp;</td>')
-    for i in range(1, lecture_room['columns'] + 1):
+    sequence = range(1, lecture_room['columns'] + 1)
+    if options.tableturn:
+		sequence.reverse()		
+    for i in sequence:
         htmlfile.write('<td class="number">%d</td>' % i)
     htmlfile.write('</tr>\n')
-    for i in range(1, lecture_room['rows'] + 1):
+	# --
+    row_sequ = (range(1, lecture_room['rows'] + 1))
+    col_sequ = (range(1, lecture_room['columns'] + 1))
+    if options.tableturn:
+		row_sequ.reverse()
+		col_sequ.reverse()
+    for i in row_sequ:
         htmlfile.write('<tr>\n')
         htmlfile.write('<td class="number">%d</td>' % i)
-        for j in range(1, lecture_room['columns'] + 1):
+        for j in col_sequ:
             seat_data = '&nbsp;'
             seat_class = 'empty'
             if [i, j] in lecture_room['seatstoomit']:
@@ -629,13 +656,19 @@ def GenerateHtmlFileWithTableFormat(lecture_room, list_of_students_with_seats):
             elif len(students_on_this_seat) == 1:
                 student = students_on_this_seat[0]
                 seat_class = 'occupied'
-                seat_data = student['FAMILY_NAME_OF_STUDENT'] + \
+                seat_data = MangleNameIfLongerThanThresholdForHTML(student['FAMILY_NAME_OF_STUDENT'],10) + \
                     '<br />' + student['FIRST_NAME_OF_STUDENT'] + \
                     '<br />' + student['REGISTRATION_NUMBER'][:STUDENT_REGNUM_NUM_OF_DIGITS_SHOWN] + 'X'*STUDENT_REGNUM_MASK_LEN
             htmlfile.write('<td class="%s">%s</td>' % (seat_class, seat_data))
+        htmlfile.write('<td class="number">%d</td>' % i)
         htmlfile.write('\n</tr>\n')
+    htmlfile.write('<tr>\n')
+    htmlfile.write('<td class="number">&nbsp;</td>')
+    for i in sequence:
+        htmlfile.write('<td class="number">%d</td>' % i)
+    htmlfile.write('</tr>\n')
+    htmlfile.write('</tbody>\n')
     htmlfile.write('</table>')
-
     htmlfile.write('</body>\n')
     htmlfile.write('</html>\n')
     htmlfile.flush()
@@ -649,9 +682,10 @@ def compare_students_by_row_and_seat(a, b):
 
 def GenerateTextfileSortedBySeat(lecture_room, list_of_students_with_seats):
 
-    txtfile = open(FILENAME_MAIN_BY_SEATS_WITHOUT_EXTENSION + '.txt', 'w')
+    txtfile = codecs.open(FILENAME_MAIN_BY_SEATS_WITHOUT_EXTENSION + '.txt', 'w','utf-8')
+    
     if options.pdf:
-        latexfile = open(TEMP_FILENAME_STUDENTS_BY_SEATS_TEXFILE, 'w')
+        latexfile = codecs.open(TEMP_FILENAME_STUDENTS_BY_SEATS_TEXFILE, 'w', 'utf-8')
 
     ## ASCII/txt file header
     txtfile.write("               Seating plan     " + lecture_room['name'] + "      by seat\n\n")
@@ -786,9 +820,9 @@ openright%
 ]{scrartcl}
 
 %% encoding:
-\\usepackage[ansinew]{inputenc}
+%%\\usepackage[ansinew]{inputenc}
 \\usepackage{ucs}
-%\\usepackage[utf8x]{inputenc}  %% Sorry, problems with Umlauts in CSV forced me to stay at ansinew
+\\usepackage[utf8x]{inputenc}  %% Sorry, problems with Umlauts in CSV forced me to stay at ansinew
 
 %% use up as much space as possible:
 \\usepackage{savetrees}
@@ -820,11 +854,11 @@ openright%
 \\clearscrheadings
 \\clearscrplain
 \\chead{Exam Checklist of Lecture Room ''' + lecture_room['name'] + '''}
-\\ifoot{\\scriptsize{}page~\\pagemark}
-\\ofoot{\\tiny{}Generated using GenerateSeatingPlan.py by Karl Voit}
+\\ifoot[c]{\\scriptsize{}page~\\pagemark}
+%%\\ofoot{\\tiny{}Generated using GenerateSeatingPlan.py by Karl Voit}
 
 \\begin{document}
-
+\setlength{\parindent}{0cm} %%remove the intendation of the first line of paragraph. 
 \\newcommand{\\vkExamStudent}[6]{%%
 \\makebox[\\linewidth][l]{$\\bigcirc$~#2~{\\bf{}#1};~#3,~R#4~S#6}\\\\[3mm]%%
 }%%

--- a/GenerateSeatingPlan.py
+++ b/GenerateSeatingPlan.py
@@ -164,6 +164,22 @@ HS_VI = { 'rows': 11,
 ##          'seatstoomit': [ [1, 1], [1,2], [1,3], [1,4], [1,5], [1,6], [1,7], [1,8], [1,9], [2,1], [2,2], [2,3], [2,4], [2,5], [2,6], [2,7], [2,8], [2,9]]
 }
 
+## Christian Schindler 20170602.
+## Longest (last) row has theoretically 20 seats. practically 11.
+## Due to the odd geometry of the room, the first row hast 14 seats.
+## First row: without tables, two seats are for wheelchairs.
+HS_I = { 'rows':15,
+         'columns':20,
+         'name': "Hoersaal I",
+         'seatstoomit':[ [1,1], [1,2], [1,3], [1,4], [1,5], [1,6], [1,7], [1,8], [1,9], [1,10], [1,11], [1,12], [1,13],
+                         [1,14], [1,15], [1,16], [1,17], [1,18], [1,19], [1,20], [2,16], [2,17], [2,18], [2,19], [2,20],
+                         [3,16], [3,17], [3, 18], [3,19], [3, 20],[4,16], [4,17], [4,18], [4,19], [4,20],
+                         [5,17], [5,18], [5, 19], [5,20], [6,17], [6,18], [6,19], [6,20],
+                         [7,17], [7,18], [7, 19], [7,20], [8,18], [8,19], [8,20], [9,18], [9,19], [9,20],
+                         [10,19], [10,20], [11,19], [11,20], [12,19], [12,20], [13,20], [14,20],
+                         [15,1], [15,2], [15,3], [15,4], [15,5], [15,6], [15,7], [15,8]]
+}
+
 HS_test1 = {'rows': 4,
         'columns': 7,
         'name': "Test-Hoersaal",
@@ -183,6 +199,7 @@ LIST_OF_LECTURE_ROOMS = [\
         {'name': "HS_H", 'data': HS_H}, \
         {'name': "HS_P1", 'data': HS_P1}, \
         {'name': "HS_VI", 'data': HS_VI},\
+        {'name': "HS_I", 'data': HS_I},\
         {'name': "test1", 'data': HS_test1} \
         ]
 
@@ -231,6 +248,10 @@ NUM_FREE_SEATS = NUM_FREE_SEATS_DEFAULT_VALUE
 NUM_FREE_ROWS_DEFAULT_VALUE = 1
 NUM_FREE_ROWS = NUM_FREE_ROWS_DEFAULT_VALUE
 
+STUDENT_REGNUM_LEN = 8
+STUDENT_REGNUM_NUM_OF_DIGITS_SHOWN = 5
+STUDENT_REGNUM_MASK_LEN = STUDENT_REGNUM_LEN - STUDENT_REGNUM_NUM_OF_DIGITS_SHOWN
+
 SEED = float(0.0)  # default
 
 USAGE = "\n\
@@ -264,10 +285,10 @@ parser.add_option("--sa", "--students_adjoined", dest="students_side_by_side",
 parser.add_option("--ra", "--filled_rows_adjoined", dest="occupied_row_before_empty_line",
                   help="that many rows are being filled with students before the next empty row(s)", metavar="INT")
 
-parser.add_option("--fs", "--free_seats_to_seperate", dest="num_free_seats",
+parser.add_option("--fs", "--free_seats_to_separate", dest="num_free_seats",
                   help="that many seats are empty before the next student sits", metavar="INT")
 
-parser.add_option("--fr", "--free_rows_to_seperate", dest="num_free_rows",
+parser.add_option("--fr", "--free_rows_to_separate", dest="num_free_rows",
                   help="that many rows are empty before the next row is filled", metavar="INT")
 
 parser.add_option("-s", "--seed", dest="seed", type="float",
@@ -534,7 +555,7 @@ def GenerateTextfileSortedByStudentLastname(lecture_room, list_of_students_with_
     for student in list_of_students_with_seats:
         file.write(student['FAMILY_NAME_OF_STUDENT'].ljust(25, '.') + \
             student['FIRST_NAME_OF_STUDENT'].ljust(20, '.') + \
-            student['REGISTRATION_NUMBER'][:4] + 'XXX'.ljust(10, '.') + \
+            student['REGISTRATION_NUMBER'][:STUDENT_REGNUM_NUM_OF_DIGITS_SHOWN] + ('X'*STUDENT_REGNUM_MASK_LEN).ljust(10, '.') + \
             "  row " + str(student['seat'][0]).rjust(3) + "/" + str(chr(64 + student['seat'][0])) + \
             "  seat " + str(student['seat'][1]).rjust(3) + "\n\n")
 
@@ -548,7 +569,7 @@ def GenerateLatexfileSortedByStudentLastname(lecture_room, list_of_students_with
     for student in list_of_students_with_seats:
         file.write("\\vkExamStudent{" + student['FAMILY_NAME_OF_STUDENT'] + '}{' + \
             student['FIRST_NAME_OF_STUDENT'] + '}{' + \
-            student['REGISTRATION_NUMBER'][:4] + 'XXX}{' + \
+            student['REGISTRATION_NUMBER'][:STUDENT_REGNUM_NUM_OF_DIGITS_SHOWN] + 'X'*STUDENT_REGNUM_MASK_LEN+'}{' + \
             str(student['seat'][0]) + '}{' + \
             str(chr(64 + student['seat'][0])) + '}{' + \
             str(student['seat'][1]) + '}' + "\n")
@@ -607,7 +628,7 @@ def GenerateHtmlFileWithTableFormat(lecture_room, list_of_students_with_seats):
                 seat_class = 'occupied'
                 seat_data = student['FAMILY_NAME_OF_STUDENT'] + \
                     '<br />' + student['FIRST_NAME_OF_STUDENT'] + \
-                    '<br />' + student['REGISTRATION_NUMBER'][:4] + 'XXX'
+                    '<br />' + student['REGISTRATION_NUMBER'][:STUDENT_REGNUM_NUM_OF_DIGITS_SHOWN] + 'X'*STUDENT_REGNUM_MASK_LEN
             htmlfile.write('<td class="%s">%s</td>' % (seat_class, seat_data))
         htmlfile.write('\n</tr>\n')
     htmlfile.write('</table>')

--- a/GenerateSeatingPlan.py
+++ b/GenerateSeatingPlan.py
@@ -855,7 +855,7 @@ openright%
 \\clearscrplain
 \\chead{Exam Checklist of Lecture Room ''' + lecture_room['name'] + '''}
 \\ifoot[c]{\\scriptsize{}page~\\pagemark}
-%%\\ofoot{\\tiny{}Generated using GenerateSeatingPlan.py by Karl Voit}
+\\ofoot{\\tiny{}Generated using GenerateSeatingPlan.py by Karl Voit}
 
 \\begin{document}
 \setlength{\parindent}{0cm} %%remove the intendation of the first line of paragraph. 

--- a/GenerateSeatingPlan.py
+++ b/GenerateSeatingPlan.py
@@ -27,9 +27,10 @@ import logging
 import os
 from optparse import OptionParser
 from random import *
+import codecs
 
 ## for CSV
-import csv
+import unicodecsv as csv
 
 ## debugging:   for setting a breakpoint:  pdb.set_trace()
 #import pdb
@@ -342,8 +343,10 @@ def handle_logging():
 
 
 def ReadInStudentsFromCsv(csvfilename):
-
-    csvReader = csv.DictReader(open(csvfilename), delimiter=';', quotechar='"')
+    csvFile = open(csvfilename,"rb")
+    ## get rid of utf-8 BOM since unicodecsv can't deal with that an quotes first key
+    csvFile.read(3) 
+    csvReader = csv.DictReader(csvFile, delimiter=';', quotechar='"', encoding="utf-8")
     students_list = []
 
     for row in csvReader:
@@ -548,10 +551,10 @@ def GenerateTextfileSortedByStudentLastname(lecture_room, list_of_students_with_
     # well we need to sort the student list if the function name says so!
     list_of_students_with_seats.sort(key=lambda s: s['FAMILY_NAME_OF_STUDENT'])
 
-    file = open(FILENAME_MAIN_BY_LASTNAME_WITHOUT_EXTENSION + '.txt', 'w')
+    file = codecs.open(FILENAME_MAIN_BY_LASTNAME_WITHOUT_EXTENSION + '.txt', 'w','utf-8')
 
     file.write("               Seating plan     " + lecture_room['name'] + "      by last name\n\n")
-
+            
     for student in list_of_students_with_seats:
         file.write(student['FAMILY_NAME_OF_STUDENT'].ljust(25, '.') + \
             student['FIRST_NAME_OF_STUDENT'].ljust(20, '.') + \
@@ -564,7 +567,7 @@ def GenerateLatexfileSortedByStudentLastname(lecture_room, list_of_students_with
     # well we need to sort the student list if the function name says so!
     list_of_students_with_seats.sort(key=lambda s: s['FAMILY_NAME_OF_STUDENT'])
 
-    file = open(TEMP_FILENAME_STUDENTS_BY_LASTNAME_TEXFILE, 'w')
+    file = codecs.open(TEMP_FILENAME_STUDENTS_BY_LASTNAME_TEXFILE, 'w', 'utf-8')
 
     for student in list_of_students_with_seats:
         file.write("\\vkExamStudent{" + student['FAMILY_NAME_OF_STUDENT'] + '}{' + \
@@ -703,9 +706,9 @@ openright%
 ]{scrartcl}
 
 %% encoding:
-\\usepackage[ansinew]{inputenc}
+%\\usepackage[ansinew]{inputenc}
 \\usepackage{ucs}
-%\\usepackage[utf8x]{inputenc}  %% Sorry, problems with Umlauts in CSV forced me to stay at ansinew
+\\usepackage[utf8x]{inputenc}  %% Sorry, problems with Umlauts in CSV forced me to stay at ansinew
 
 %% use up as much space as possible:
 \\usepackage{savetrees}


### PR DESCRIPTION
introduced CHANGELOG.md 
utf8 support: this script makes more sense if able to deal with utf-8 exported cvs from TUG-Online
html seating plan: names are now truncated if too long; Turning table with option -u is now browser independent
